### PR TITLE
Pet Disappearance

### DIFF
--- a/Scripts/Mobiles/PlayerMobile.cs
+++ b/Scripts/Mobiles/PlayerMobile.cs
@@ -6150,7 +6150,7 @@ namespace Server.Mobiles
                         continue;
                     }
 
-                    if (!pet.CanAutoStable || Stabled.Count >= AnimalTrainer.GetMaxStabled(this))
+                    if (!pet.CanAutoStable || Stabled.Count >= AnimalTrainer.GetMaxStabled(this) + 1 )
                     {
                         continue;
                     }


### PR DESCRIPTION
When the maximum amount of pets stored in the player's stable is logged out with the pet, the pet disappears.
It can be modified by adding 1 to the maximum pet storage.
![pet_logout](https://user-images.githubusercontent.com/22042552/138380024-0a86e129-47ea-45cd-8388-69139eb9b545.gif)


