### PR TITLE
Efficient method

### DIFF
--- a/Scripts/Mobiles/PlayerMobile.cs
+++ b/Scripts/Mobiles/PlayerMobile.cs
@@ -6130,7 +6130,7 @@ namespace Server.Mobiles
 
         public void AutoStablePets()
         {
-            if (AllFollowers.Count > 0)
+            if (AllFollowers.Count > 0 && Stabled.Count <= AnimalTrainer.GetMaxStabled(this))
             {
                 for (int i = m_AllFollowers.Count - 1; i >= 0; --i)
                 {
@@ -6150,7 +6150,7 @@ namespace Server.Mobiles
                         continue;
                     }
 
-                    if (!pet.CanAutoStable || Stabled.Count >= AnimalTrainer.GetMaxStabled(this) + 1 )
+                    if (!pet.CanAutoStable)
                     {
                         continue;
                     }


### PR DESCRIPTION
Most of the pets used for hunting are 4-5 slots, so I just modified it to +1. But this method could not be solved when there were double 2 slot pets. Therefore, the method of correction has been changed.